### PR TITLE
Ref:- Move mutating logic from models to controllers.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,6 +115,8 @@ dist
 # DynamoDB Local files
 .dynamodb/
 
+sqlite.db
+
 # TernJS port file
 .tern-port
 

--- a/src/controllers/chain.ts
+++ b/src/controllers/chain.ts
@@ -22,7 +22,14 @@ export const getChain = async (id: number) => {
   const { type, returnIntermediateSteps } = res.data;
 
   chain.initialType = type;
-  chain.returnIntermediateSteps = returnIntermediateSteps;
+  chain.initialReturnIntermediateSteps = returnIntermediateSteps;
 
   return chain;
+};
+
+export const setType = async (id: number, type: string) => {
+  await axios(`/api/chain/${id}`, {
+    method: "POST",
+    data: { type },
+  });
 };

--- a/src/controllers/openAI.ts
+++ b/src/controllers/openAI.ts
@@ -23,3 +23,10 @@ export const getOpenAI = async (id: number) => {
 
   return openAI;
 };
+
+export const setTemperature = async (id: number, temperature: number) => {
+  await axios(`/api/openAI/${id}`, {
+    method: "POST",
+    data: { temperature },
+  });
+};

--- a/src/models/BaseLLM/OpenAI.ts
+++ b/src/models/BaseLLM/OpenAI.ts
@@ -1,9 +1,10 @@
 import axios from "axios";
 
-//export class OpenAI
-//extends BaseLLM<OpenAICallOptions>
-// implements OpenAIInput, AzureOpenAIInput
+import { setTemperature } from "@/controllers/openAI";
 
+// export class OpenAI
+// extends BaseLLM<OpenAICallOptions>
+// implements OpenAIInput, AzureOpenAIInput
 
 export default class OpenAI {
   private readonly _id: number;
@@ -29,7 +30,7 @@ export default class OpenAI {
 
   // unable to use currently
   async getTemperature(): Promise<number> {
-    return axios(`/api/openAI/${this._id}`).then((res) => {
+    return axios(`/api/openAI/${this.id}`).then((res) => {
       const { temperature } = res.data;
 
       return temperature;
@@ -37,9 +38,6 @@ export default class OpenAI {
   }
 
   async setTemperature(value: number) {
-    await axios(`/api/openAI/${this._id}`, {
-      method: "POST",
-      data: { temperature: value },
-    });
+    await setTemperature(this.id, value);
   }
 }

--- a/src/models/Chains/LoadSummarizationChain.ts
+++ b/src/models/Chains/LoadSummarizationChain.ts
@@ -1,5 +1,7 @@
 import axios from "axios";
 
+import { setType } from "@/controllers/chain";
+
 // export const loadSummarizationChain = (
 //  llm: BaseLanguageModel,
 //  params: SummarizationChainParams = { type: "map_reduce" }
@@ -10,12 +12,12 @@ export default class LoadSummarizationChain {
 
   private _initialType: string;
 
-  private _returnIntermediateSteps: boolean;
+  private _initialReturnIntermediateSteps: boolean;
 
   constructor(id: number) {
     this._id = id;
     this._initialType = "";
-    this._returnIntermediateSteps = false;
+    this._initialReturnIntermediateSteps = false;
   }
 
   get id(): number {
@@ -30,19 +32,16 @@ export default class LoadSummarizationChain {
     this._initialType = value;
   }
 
-  get returnIntermediateSteps() {
-    return this._returnIntermediateSteps;
+  get initialReturnIntermediateSteps() {
+    return this._initialReturnIntermediateSteps;
   }
 
-  set returnIntermediateSteps(value) {
-    this._returnIntermediateSteps = value;
+  set initialReturnIntermediateSteps(value) {
+    this._initialReturnIntermediateSteps = value;
   }
 
   async setType(value: string) {
-    await axios(`/api/chain/${this._id}`, {
-      method: "POST",
-      data: { type: value },
-    });
+    setType(this.id, value);
   }
 
   async setReturnIntermediateSteps(value: boolean) {

--- a/src/views/Nodes/LoadSummarizationChainNode.ts
+++ b/src/views/Nodes/LoadSummarizationChainNode.ts
@@ -1,9 +1,9 @@
 //  view for the loadSummarizationChain node
 
-//export const loadSummarizationChain = (
+// export const loadSummarizationChain = (
 //  llm: BaseLanguageModel,
 //  params: SummarizationChainParams = { type: "map_reduce" }
-//)
+// )
 
 import { ClassicPreset } from "rete";
 

--- a/src/views/Nodes/RecursiveCharacterTextSplitter.ts
+++ b/src/views/Nodes/RecursiveCharacterTextSplitter.ts
@@ -4,7 +4,7 @@ import { ClassicPreset } from "rete";
 
 import OpenAI from "@/models/TextSplitters/RecursiveCharacterTextSplitter";
 
-export default class RecursizeCharacterTextSplitterNode extends ClassicPreset.Node<
+export default class RecursiveCharacterTextSplitterNode extends ClassicPreset.Node<
   {},
   {},
   { temperature: ClassicPreset.InputControl<"number"> }


### PR DESCRIPTION
Partially closes #10 (point 1)

`OpenAI` and `LoadSummarizationChain` models now only contain accessors. All their mutating logic has been moved to respective controllers.